### PR TITLE
support writing to excel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
   - pip install flake8 mock unittest2
   - pip install -e .

--- a/catsql/cmdline.py
+++ b/catsql/cmdline.py
@@ -66,6 +66,9 @@ def add_options(parser):
     parser.add_argument('--sqlite', nargs=1, required=False, default=None,
                         help='Save results to a sqlite file.')
 
+    parser.add_argument('--excel', nargs=1, required=False, default=None,
+                        help='Save results to an excel file.')
+
     parser.add_argument('--table', action='append',
                         help='Table to include (defaults to all tables). '
                         'Can be a comma separated list of multiple tables.')

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup
 
 install_requires = [
     "daff >= 1.3.14",
+    "openpyxl >= 2.4.1",
     "six >= 1.7.3",
     "SQLAlchemy >= 1.0.11"
 ]
@@ -13,7 +14,7 @@ if sys.version_info[0] == 2:
     install_requires.append('unicodecsv')
 
 setup(name="catsql",
-      version="0.3.4",
+      version="0.3.5",
       author="Paul Fitzpatrick",
       author_email="paulfitz@alum.mit.edu",
       description="Display a quick view of sql databases (and make quick edits)",

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -67,6 +67,11 @@ class TestCommands(unittest2.TestCase):
         result = self.workspace.output_json()
         assert result['count'] == 5
 
+    def test_excel_basic(self):
+        catsql([self.workspace.number_db, "--excel", self.workspace.output_file_excel])
+        result = self.workspace.output_excel()
+        assert len(list(result.active)) == 5 + 1
+
     def test_terse_kv(self):
         catsql([self.workspace.number_db, "--terse",
                 "--value", "DIGIT=4",

--- a/tests/workspace.py
+++ b/tests/workspace.py
@@ -1,5 +1,6 @@
 import csv
 import json
+import openpyxl
 import os
 import re
 import six
@@ -47,6 +48,7 @@ class Workspace(object):
         self.number_db = 'sqlite:///{}'.format(self.number_file)
         self.output_file = "{}/output.txt".format(self.work)
         self.output_file_sql = "{}/output.sqlite".format(self.work)
+        self.output_file_excel = "{}/output.xlsx".format(self.work)
         self.output_text_cache = None
 
     def filename(self, partial_filename):
@@ -79,3 +81,6 @@ class Workspace(object):
 
     def output_json(self):
         return json.loads(self.output_text())
+
+    def output_excel(self):
+        return openpyxl.load_workbook(filename=self.output_file_excel)


### PR DESCRIPTION
Analogous to storing query results in a local sqlite db, this stores results in an excel file.

Editing a slice of an enormous remote sql db in a local spreadsheet program is now just one step away.  Inspired by http://datadiff.blogspot.com/2011/04/editing-mysql-tables-in-gnumeric-or.html