### PR TITLE
flatten dates to a string when saving json

### DIFF
--- a/catsql/main.py
+++ b/catsql/main.py
@@ -32,6 +32,13 @@ else:
 warnings.simplefilter("ignore", category=SAWarning)
 
 
+def flatten_date(obj):
+    if isinstance(obj, datetime):
+        serial = obj.isoformat()
+        return serial
+    raise TypeError("No change needed")
+
+
 # Get approximate length of header
 class CsvRowWriter(object):
     def __init__(self):
@@ -455,8 +462,11 @@ class Viewer(object):
                 od[names[i]] = row[idx]
             results.append(od)
         result['count'] = len(results)
+
         with open(filename, 'w') as fout:
-            fout.write(json.dumps(result, indent=2))
+            fout.write(json.dumps(result,
+                                  indent=2,
+                                  default=flatten_date))
 
 
 def catsql(sys_args):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.version_info[0] == 2:
     install_requires.append('unicodecsv')
 
 setup(name="catsql",
-      version="0.3.6",
+      version="0.3.7",
       author="Paul Fitzpatrick",
       author_email="paulfitz@alum.mit.edu",
       description="Display a quick view of sql databases (and make quick edits)",


### PR DESCRIPTION
There's no systematic representation of dates in json, so we just convert them to a string.  This is to avoid json export being impossible if there is a datetime field.