### PR TITLE
filter floats correctly when null

### DIFF
--- a/catsql/daffsql/sqlalchemy_helper.py
+++ b/catsql/daffsql/sqlalchemy_helper.py
@@ -41,7 +41,7 @@ class SqlAlchemyHelper(daff.SqlHelper):
                         is_float = True
                 except Exception:
                     pass
-        if is_float:
+        if is_float and value is not None:
             # use epsilon
             q = q.where(tab.c[key] > float(value) - EPSILON)
             q = q.where(tab.c[key] < float(value) + EPSILON)


### PR DESCRIPTION
`catsql [filters] --edit` can fail to patch rows that have `null` in floating point columns.  This fixes that case.